### PR TITLE
tech(CI): update version of checkout and add build status badge

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: Node_CI
 
 on: [pull_request,push]
 
@@ -9,10 +9,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://github.com/ExpediaGroup/determination/workflows/Node_CI/badge.svg)
+
 # determination
 
 Configuration resolver. `@vrbo/determination` loads a JSON configuration file, resolving against criteria using [confidence](https://github.com/hapijs/confidence) and [shortstop](https://github.com/krakenjs/shortstop) protocol handlers.


### PR DESCRIPTION
Just updating to `checkout@v2` to keep in line with our other modules and adding the build status badge to the Readme